### PR TITLE
Fix for issue with this.userAgent

### DIFF
--- a/lib/nest-api.js
+++ b/lib/nest-api.js
@@ -135,7 +135,7 @@ NestApi = (function() {
       path: path,
       method: 'GET',
       headers: {
-        'User-Agent': this.userAgent,
+        'User-Agent': userAgent,
         'X-nl-user-id': session.userid,
         'X-nl-protocol-version': '1',
         'Accept-Language': 'en-us',


### PR DESCRIPTION
When trying to use this to authenticate with Nest, needed to remove 'this.' from 'this.userAgent' to be able to access the variable - else it appears undefined.
