### PR TITLE
Use userAgent instead of @userAgent in getter method

### DIFF
--- a/lib/nest-api.js
+++ b/lib/nest-api.js
@@ -16,7 +16,7 @@ NEST_API_PORT = 443;
 NEST_API_LOGIN_PATH = '/user/login';
 
 NestApi = (function() {
-  var password, session, userAgent, username;
+  var password, session, username;
 
   username = null;
 
@@ -24,7 +24,7 @@ NestApi = (function() {
 
   session = {};
 
-  userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17";
+  NestApi.userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17";
 
   function NestApi(username1, password1) {
     this.username = username1 != null ? username1 : null;
@@ -89,7 +89,7 @@ NestApi = (function() {
       method: 'POST',
       headers: {
         'Content-Type': contentType,
-        'User-Agent': userAgent,
+        'User-Agent': NestApi.userAgent,
         'Content-Length': post_data.length
       }
     };
@@ -135,7 +135,7 @@ NestApi = (function() {
       path: path,
       method: 'GET',
       headers: {
-        'User-Agent': this.userAgent,
+        'User-Agent': NestApi.userAgent,
         'X-nl-user-id': session.userid,
         'X-nl-protocol-version': '1',
         'Accept-Language': 'en-us',

--- a/src/nest-api.coffee
+++ b/src/nest-api.coffee
@@ -117,7 +117,7 @@ class NestApi
       path: path
       method: 'GET'
       headers:
-        'User-Agent': @userAgent
+        'User-Agent': userAgent
         'X-nl-user-id': session.userid
         'X-nl-protocol-version': '1'
         'Accept-Language': 'en-us'

--- a/src/nest-api.coffee
+++ b/src/nest-api.coffee
@@ -11,7 +11,7 @@ class NestApi
   username  = null
   password  = null
   session   = {}
-  userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2)
+  @userAgent:  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2)
               AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0
               Safari/537.17"
 
@@ -76,7 +76,7 @@ class NestApi
       method: 'POST'
       headers:
         'Content-Type': contentType
-        'User-Agent': userAgent
+        'User-Agent': NestApi.userAgent
         'Content-Length': post_data.length
 
     if @session and @session.access_token
@@ -117,7 +117,7 @@ class NestApi
       path: path
       method: 'GET'
       headers:
-        'User-Agent': userAgent
+        'User-Agent': NestApi.userAgent
         'X-nl-user-id': session.userid
         'X-nl-protocol-version': '1'
         'Accept-Language': 'en-us'


### PR DESCRIPTION
This solves the same problem as johnwyles/node-nest-api#4 but is uses the User-Agent that was already in there. I think this is probably a cleaner fix, though (because it's what `post` is doing already).